### PR TITLE
Do not return empty object on null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ function mapScalars(data: any, path: PropertyKey[], map: ScalarMapper) {
         mapScalars(subData, subPath, map)
       );
       return newData;
+    } else if (newSubData[segment] === null) {
+      return newData;
     } else {
       newSubData[segment] = { ...newSubData[segment] };
     }


### PR DESCRIPTION
I ran over a bug where the exchange converted a `null` to `{}`.
This change fixes that.