### PR TITLE
feat: support repeated usages of the same fragment

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -124,6 +124,26 @@ const fragment2 = {
   calls: 2,
 };
 
+const repeatedFragment = {
+  query: gql`
+    fragment SomeFragment on Nested {
+      name
+    }
+
+    {
+      first: nested {
+        ...SomeFragment
+      }
+
+      second: nested {
+        ...SomeFragment
+      }
+    }
+  `,
+  data: { first: nestedData, second: nestedData },
+  calls: 2,
+};
+
 test.each([
   fragment1,
   fragment2,
@@ -132,6 +152,7 @@ test.each([
   listNestedNullable,
   nested,
   nestedNullable,
+  repeatedFragment,
   simple,
 ])('works on different structures', ({ query, data, calls }) => {
   const op = client.createRequestOperation('query', { key: 1, query });

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,7 @@ export default function scalarExchange({
 
         const spreadFragmentsInQuery: Record<
           string,
-          FragmentSpreadInQuery
+          FragmentSpreadInQuery[]
         > = {};
         const scalarsInQuery: ScalarInQuery[] = [];
 
@@ -229,22 +229,24 @@ export default function scalarExchange({
             scalarsInQuery.push(nodeOfInterest as ScalarInQuery);
           } else {
             const { name } = nodeOfInterest;
-            spreadFragmentsInQuery[
-              name
-            ] = nodeOfInterest as FragmentSpreadInQuery;
+            spreadFragmentsInQuery[name] = spreadFragmentsInQuery[name] ?? [];
+            spreadFragmentsInQuery[name].push(
+              nodeOfInterest as FragmentSpreadInQuery
+            );
           }
         }
 
         for (const { fragmentName, name, path } of scalarsInQuery) {
           if (fragmentName && spreadFragmentsInQuery[fragmentName]) {
-            const { path: pathToFragment } = spreadFragmentsInQuery[
+            for (const { path: pathToFragment } of spreadFragmentsInQuery[
               fragmentName
-            ];
-            args.data = mapScalar(
-              args.data,
-              [...pathToFragment, ...path],
-              scalars[name]
-            );
+            ]) {
+              args.data = mapScalar(
+                args.data,
+                [...pathToFragment, ...path],
+                scalars[name]
+              );
+            }
           } else {
             args.data = mapScalar(args.data, path, scalars[name]);
           }


### PR DESCRIPTION
When given a query looking like this:
```graphql
query CoursesQuery {
  upcoming: courses(type: UPCOMING) {
    id
    ...CourseDetails
  }

  past: courses(type: PAST) {
    id
    ...CourseDetails
  }
}
```
then the exchange will only map the scalars in the last usage of the `CourseDetails` (the one with key `past`).
This PR changes `const spreadFragmentsInQuery` from `Record<string, FragmentSpreadInQuery>` to `Record<string, FragmentSpreadInQuery[]>`, with the effect that the exchange now maps scalars in both usages.