### PR TITLE
feat: support urql/core 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "tsdx build"
   },
   "peerDependencies": {
-    "@urql/core": "^1.12.3 || ^2.0.0 || ^3.0.0",
+    "@urql/core": "^1.12.3 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "graphql": "^15.3.0 || ^16.0.0",
     "wonka": "^4.0.14 || ^6.0.0"
   },
@@ -37,7 +37,7 @@
   "author": "Christian Lentfort",
   "module": "dist/urql-custom-scalars-exchange.esm.js",
   "devDependencies": {
-    "@urql/core": "^3.0.0",
+    "@urql/core": "^4.0.0",
     "graphql": "^16.0.0",
     "graphql-tag": "^2.12.6",
     "husky": "^4.2.5",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,6 +3,8 @@ import {
   Operation,
   OperationResult,
   createClient,
+  cacheExchange,
+  fetchExchange,
 } from '@urql/core';
 import { IntrospectionQuery } from 'graphql';
 import gql from 'graphql-tag';
@@ -12,12 +14,16 @@ import scalarExchange from '../';
 import schema from './__fixtures__/schema.json';
 
 const dispatchDebug = jest.fn();
+const defaultExchanges = [cacheExchange, fetchExchange];
 
-let client = createClient({ url: 'http://0.0.0.0' });
+let client = createClient({
+  url: 'http://0.0.0.0',
+  exchanges: defaultExchanges,
+});
 let { source: ops$, next } = makeSubject<Operation>();
 
 beforeEach(() => {
-  client = createClient({ url: 'http://0.0.0.0' });
+  client = createClient({ url: 'http://0.0.0.0', exchanges: defaultExchanges });
   ({ source: ops$, next } = makeSubject<Operation>());
 });
 
@@ -167,6 +173,8 @@ test.each([
       return {
         operation: forwardOp,
         data: { __typename: 'Query', ...data },
+        stale: false,
+        hasNext: false,
       };
     }
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@0no-co/graphql.web@^1.0.1":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz#9606eb651955499525d068ce0ad8bea596286ce2"
+  integrity sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -951,11 +956,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@graphql-typed-document-node/core@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
-  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -1477,13 +1477,13 @@
     "@typescript-eslint/types" "5.33.1"
     eslint-visitor-keys "^3.3.0"
 
-"@urql/core@^3.0.0":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-3.0.5.tgz#a26c326dd788d6d6abb839493bce86147f5a45c9"
-  integrity sha512-6/1HG+WEAcPs+hXSFnxWBTWkNUwa8dj2cHysWokMaFIbAioGtUaSdxp2q9FDMtWAIGdc640NFSt2B8itGLdoAA==
+"@urql/core@^4.0.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.1.1.tgz#b1312eb0ecbc91e315457a3ec14741321cbee1c7"
+  integrity sha512-iIoAy6BY+BUZZ7KIpnMT7C9q+ULf5ZCVxGe3/i7WZSJBrQa2h1QkIMhL+8fAKmOn9gt83jSIv5drWWnhZ9izEA==
   dependencies:
-    "@graphql-typed-document-node/core" "^3.1.1"
-    wonka "^6.0.0"
+    "@0no-co/graphql.web" "^1.0.1"
+    wonka "^6.3.2"
 
 abab@^2.0.0:
   version "2.0.5"
@@ -6450,6 +6450,11 @@ wonka@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.1.0.tgz#65297ebf7031ae46d4b0c56da93950fb3ae5baaa"
   integrity sha512-VgiMCz7BXOiDbgpVhf5iNhK7hurteY5Jv0fDJewUkY0s4fbxQD2iKqfGxNXNTwp2v3bgT8QVu2l5H7YdkZ5WIA==
+
+wonka@^6.3.2:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.3.tgz#aa99fa5f9303a32517497918fdd0208175e7edbe"
+  integrity sha512-id4wYGsT6aEc8/3+by7NTHvTe0DwsOjv7vah0K0+AorV1MHKuS3OQ2g8DGsem1OEXrNShbVLPsg4kG2O6GZ2SQ==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Aims to close #24 

I am not sure if the exchanges are actually needed but my intention was to preserve previous behaviour which in urql 3 was to use default exchanges. Since those are not available anymore, I used what it says in the [v4 Announcement](https://github.com/urql-graphql/urql/issues/3114#no-more-defaultexchanges-).

As for `hasNext` and `stale`, I assumed they should be false, since in the test it makes the most sense ([link to that section in the announcement](https://github.com/urql-graphql/urql/issues/3114#hasnext-stale-and-multiple-results-)).